### PR TITLE
Add no-op to aws_security_group_rules

### DIFF
--- a/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
+++ b/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
@@ -11,8 +11,7 @@ aws_security_groups = filter tfplan.resource_changes as _, resource_changes {
 aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes {
 	resource_changes.mode is "managed" and
 		resource_changes.type is "aws_security_group_rule" and
-		(resource_changes.change.actions contains "create" or
-			resource_changes.change.actions is ["update"]) and
+        resource_changes.change.actions in [["update"], ["create"], ["no-op"]] and
 		resource_changes.change.after.type is "ingress"
 }
 


### PR DESCRIPTION
check for no-op in resource_changes.change.actions so that existing security groups are also subject to the checks for rule `deny_public_ssh_security_group_rules`