### PR TITLE
Update deny-public-ssh-acl-rules.md

### DIFF
--- a/docs/policies/deny-public-ssh-acl-rules.md
+++ b/docs/policies/deny-public-ssh-acl-rules.md
@@ -22,7 +22,7 @@ trace:
                        when port is "22" or protocl is "-1"
           --------------------------------------------------------
           Ensure no security groups allow ingress from 0.0.0.0/0
-          to port 3389.
+          to port 22.
           --------------------------------------------------------
 
         Value:


### PR DESCRIPTION
Documentation is incorrect. Port 3389 is listed instead of port 22