### PR TITLE
Removed multi-line comment from main rule

### DIFF
--- a/docs/policies/deny-public-rdp-acl-rules.md
+++ b/docs/policies/deny-public-rdp-acl-rules.md
@@ -10,23 +10,17 @@ Removing unfettered connectivity to remote console services, such as RDP, reduce
 ## Policy Results (Pass)
 ```bash
 trace:
-      deny-public-rdp-acl-rules.sentinel:85:1 - Rule "main"
+      deny-public-rdp-acl-rules.sentinel:72:1 - Rule "main"
         Description:
-          --------------------------------------------------------
-          Name:        deny-public-rdp-acl-rules.sentinel
-          Category:    Networking
-          Provider:    hashicorp/aws
-          Resource:    aws_security_group
-                       aws_security_group_rule
-          Check:       cidr_blocks does not contain "0.0.0.0/0"
-                       when port is "3389" or protocl is "-1"
-          --------------------------------------------------------
-          Ensure no security groups allow ingress from 0.0.0.0/0
-          to port 3389.
-          --------------------------------------------------------
+          Ensure no security groups allow ingress from 0.0.0.0/0 to port
+          3389.
 
         Value:
-          true
+          false
+
+      deny-public-rdp-acl-rules.sentinel:43:1 - Rule "deny_public_rdp_security_groups"
+        Value:
+          false
 ```
 
 ---

--- a/docs/policies/deny-public-ssh-acl-rules.md
+++ b/docs/policies/deny-public-ssh-acl-rules.md
@@ -10,23 +10,17 @@ Removing unfettered connectivity to remote console services, such as SSH, reduce
 ## Policy Results (Pass)
 ```bash
 trace:
-      deny-public-ssh-acl-rules.sentinel:85:1 - Rule "main"
+      deny-public-ssh-acl-rules.sentinel:72:1 - Rule "main"
         Description:
-          --------------------------------------------------------
-          Name:        deny-public-ssh-acl-rules.sentinel
-          Category:    Networking
-          Provider:    hashicorp/aws
-          Resource:    aws_security_group
-                       aws_security_group_rule
-          Check:       cidr_blocks does not contain "0.0.0.0/0"
-                       when port is "22" or protocl is "-1"
-          --------------------------------------------------------
-          Ensure no security groups allow ingress from 0.0.0.0/0
-          to port 22.
-          --------------------------------------------------------
+          Ensure no security groups allow ingress from 0.0.0.0/0 to port
+          22.
 
         Value:
-          true
+          false
+
+      deny-public-ssh-acl-rules.sentinel:43:1 - Rule "deny_public_ssh_security_groups"
+        Value:
+          false
 ```
 
 ---

--- a/docs/policies/restrict-all-vpc-traffic-acl-rules.md
+++ b/docs/policies/restrict-all-vpc-traffic-acl-rules.md
@@ -9,21 +9,24 @@ Configuring all VPC default security groups to restrict all traffic will encoura
 
 ## Policy Results (Pass)
 ```bash
-trace:
-      restrict-all-vpc-traffic-acl-rules.sentinel:47:1 - Rule "main"
+    trace:
+      restrict-all-vpc-traffic-acl-rules.sentinel:35:1 - Rule "main"
         Description:
-          --------------------------------------------------------
-          Name:        restrict-all-vpc-traffic-acl-rules.sentinel
-          Category:    Networking
-          Provider:    hashicorp/aws
-          Resource:    aws_default_network_acl
-          Check:       egress block is empty
-                       ingress block is empty
-          --------------------------------------------------------
-          Ensure the default security group of every VPC restricts
-          all traffic
-          --------------------------------------------------------
+          Ensure the default security group of every VPC restricts all
+          traffic
 
+        Value:
+          false
+
+      restrict-all-vpc-traffic-acl-rules.sentinel:16:1 - Rule "deny_all_vpc_inbound_acls"
+        Value:
+          false
+
+      restrict-all-vpc-traffic-acl-rules.sentinel:22:1 - Rule "deny_undefined_egress_configuration"
+        Value:
+          true
+
+      restrict-all-vpc-traffic-acl-rules.sentinel:10:1 - Rule "deny_undefined_ingress_configuration"
         Value:
           true
 ```

--- a/policies/deny-public-rdp-acl-rules/deny-public-rdp-acl-rules.sentinel
+++ b/policies/deny-public-rdp-acl-rules/deny-public-rdp-acl-rules.sentinel
@@ -68,18 +68,7 @@ deny_all_open_protocol_security_group_rules = rule {
 	}
 }
 
-// --------------------------------------------------------
-// Name:        deny-public-rdp-acl-rules.sentinel
-// Category:    Networking
-// Provider:    hashicorp/aws
-// Resource:    aws_security_group
-//              aws_security_group_rule
-// Check:       cidr_blocks does not contain "0.0.0.0/0"
-//              when port is "3389" or protocl is "-1"
-// --------------------------------------------------------
-// Ensure no security groups allow ingress from 0.0.0.0/0
-// to port 3389.
-// --------------------------------------------------------
+// Ensure no security groups allow ingress from 0.0.0.0/0 to port 3389.
 main = rule {
 	deny_public_rdp_security_groups and
 	deny_public_rdp_security_group_rules and

--- a/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
+++ b/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
@@ -40,7 +40,6 @@ protocol_security_group_rules = filter aws_security_group_rules as _, asgr {
 	asgr.change.after.protocol is "-1"
 }
 
-
 deny_public_ssh_security_groups = rule {
 	all ssh_security_groups as _, ssg {
 		all ssg.change.after.ingress as _, ingress {

--- a/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
+++ b/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
@@ -40,7 +40,6 @@ protocol_security_group_rules = filter aws_security_group_rules as _, asgr {
 	asgr.change.after.protocol is "-1"
 }
 
-print("Ensure no AWS security groups allow ingress from 0.0.0.0/0 to port 22")
 
 deny_public_ssh_security_groups = rule {
 	all ssh_security_groups as _, ssg {
@@ -70,18 +69,7 @@ deny_all_open_protocol_security_group_rules = rule {
 	}
 }
 
-// --------------------------------------------------------
-// Name:        deny-public-ssh-acl-rules.sentinel
-// Category:    Networking
-// Provider:    hashicorp/aws
-// Resource:    aws_security_group
-//              aws_security_group_rule
-// Check:       cidr_blocks does not contain "0.0.0.0/0"
-//              when port is "22" or protocl is "-1"
-// --------------------------------------------------------
-// Ensure no security groups allow ingress from 0.0.0.0/0
-// to port 22.
-// --------------------------------------------------------
+// Ensure no security groups allow ingress from 0.0.0.0/0 to port 22.
 main = rule {
 	deny_public_ssh_security_groups and
 	deny_public_ssh_security_group_rules and

--- a/policies/restrict-all-vpc-traffic-acl-rules/restrict-all-vpc-traffic-acl-rules.sentinel
+++ b/policies/restrict-all-vpc-traffic-acl-rules/restrict-all-vpc-traffic-acl-rules.sentinel
@@ -31,17 +31,7 @@ deny_all_vpc_outbound_acls = rule when deny_undefined_egress_configuration is tr
 	}
 }
 
-// --------------------------------------------------------
-// Name:        restrict-all-vpc-traffic-acl-rules.sentinel
-// Category:    Networking
-// Provider:    hashicorp/aws
-// Resource:    aws_default_network_acl
-// Check:       egress block is empty
-//              ingress block is empty
-// --------------------------------------------------------
-// Ensure the default security group of every VPC restricts
-// all traffic
-// --------------------------------------------------------
+// Ensure the default security group of every VPC restricts all traffic
 main = rule {
 	deny_undefined_ingress_configuration and
 	deny_undefined_egress_configuration and


### PR DESCRIPTION
Removing multi-line comment from the main rule for all policies so that the policy output is supported by the new Sentinel policy review UI in Terraform Cloud