### PR TITLE
fix: Handles self-referencing security groups

### DIFF
--- a/policies/deny-public-rdp-acl-rules/deny-public-rdp-acl-rules.sentinel
+++ b/policies/deny-public-rdp-acl-rules/deny-public-rdp-acl-rules.sentinel
@@ -18,26 +18,28 @@ aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes
 
 rdp_security_groups = filter aws_security_groups as _, asg {
 	any asg.change.after.ingress as _, ingress {
-		ingress.to_port is 3389 or
-			(ingress.from_port <= 3389 and
-				ingress.to_port >= 3389)
+		!ingress.self and
+			(ingress.to_port is 3389 or
+				(ingress.from_port <= 3389 and
+					ingress.to_port >= 3389))
 	}
 }
 
 rdp_security_group_rules = filter aws_security_group_rules as _, asgr {
-	asgr.change.after.to_port is 3389 or
-		(asgr.change.after.from_port <= 3389 and
-			asgr.change.after.to_port >= 3389)
+	!asgr.change.after.self and
+		(asgr.change.after.to_port is 3389 or
+			(asgr.change.after.from_port <= 3389 and
+				asgr.change.after.to_port >= 3389))
 }
 
 protocol_security_groups = filter aws_security_groups as _, asg {
 	all asg.change.after.ingress as _, ingress {
-		ingress.protocol is "-1"
+		ingress.protocol is "-1" and !ingress.self
 	}
 }
 
 protocol_security_group_rules = filter aws_security_group_rules as _, asgr {
-	asgr.change.after.protocol is "-1"
+	asgr.change.after.protocol is "-1" and !asgr.change.after.self
 }
 
 deny_public_rdp_security_groups = rule {

--- a/policies/deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/policies/deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -177,7 +177,7 @@ resource_changes = {
 				"description": "self",
 				"ingress": [
 					{
-						"cidr_blocks": null,
+						"cidr_blocks":      null,
 						"description":      "self",
 						"from_port":        3389,
 						"ipv6_cidr_blocks": [],
@@ -371,7 +371,7 @@ resource_changes = {
 				"create",
 			],
 			"after": {
-				"cidr_blocks": null,
+				"cidr_blocks":      null,
 				"description":      "self",
 				"from_port":        3389,
 				"ipv6_cidr_blocks": null,

--- a/policies/deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/policies/deny-public-rdp-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -167,6 +167,60 @@ resource_changes = {
 		"provider_name":  "aws",
 		"type":           "aws_security_group",
 	},
+	"aws_security_group.self": {
+		"address": "aws_security_group.self",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "self",
+				"ingress": [
+					{
+						"cidr_blocks": null,
+						"description":      "self",
+						"from_port":        3389,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             true,
+						"to_port":          3389,
+					},
+				],
+				"name":                   "self",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "self",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
 	"aws_security_group.seuss": {
 		"address": "aws_security_group.seuss",
 		"change": {
@@ -307,6 +361,41 @@ resource_changes = {
 		"mode":           "managed",
 		"module_address": "",
 		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.self": {
+		"address": "aws_security_group_rule.self",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": null,
+				"description":      "self",
+				"from_port":        3389,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             true,
+				"to_port":          3389,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "self",
 		"provider_name":  "aws",
 		"type":           "aws_security_group_rule",
 	},

--- a/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
+++ b/policies/deny-public-ssh-acl-rules/deny-public-ssh-acl-rules.sentinel
@@ -18,26 +18,28 @@ aws_security_group_rules = filter tfplan.resource_changes as _, resource_changes
 
 ssh_security_groups = filter aws_security_groups as _, asg {
 	any asg.change.after.ingress as _, ingress {
-		ingress.to_port is 22 or
-			(ingress.from_port <= 22 and
-				ingress.to_port >= 22)
+		!ingress.self and
+			(ingress.to_port is 22 or
+				(ingress.from_port <= 22 and
+					ingress.to_port >= 22))
 	}
 }
 
 ssh_security_group_rules = filter aws_security_group_rules as _, asgr {
-	asgr.change.after.to_port is 22 or
-		(asgr.change.after.from_port <= 22 and
-			asgr.change.after.to_port >= 22)
+	!asgr.change.after.self and
+		(asgr.change.after.to_port is 22 or
+			(asgr.change.after.from_port <= 22 and
+				asgr.change.after.to_port >= 22))
 }
 
 protocol_security_groups = filter aws_security_groups as _, asg {
 	all asg.change.after.ingress as _, ingress {
-		ingress.protocol is "-1"
+		ingress.protocol is "-1" and !ingress.self
 	}
 }
 
 protocol_security_group_rules = filter aws_security_group_rules as _, asgr {
-	asgr.change.after.protocol is "-1"
+	asgr.change.after.protocol is "-1" and !asgr.change.after.self
 }
 
 deny_public_ssh_security_groups = rule {

--- a/policies/deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/policies/deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -121,6 +121,60 @@ resource_changes = {
 				"description": "foo",
 				"ingress": [
 					{
+						"cidr_blocks": null,
+						"description":      "foo",
+						"from_port":        22,
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"protocol":         "tcp",
+						"security_groups":  [],
+						"self":             true,
+						"to_port":          22,
+					},
+				],
+				"name":                   "foo",
+				"name_prefix":            null,
+				"revoke_rules_on_delete": false,
+				"tags":     null,
+				"timeouts": null,
+			},
+			"after_unknown": {
+				"arn":    true,
+				"egress": true,
+				"id":     true,
+				"ingress": [
+					{
+						"cidr_blocks": [
+							false,
+						],
+						"ipv6_cidr_blocks": [],
+						"prefix_list_ids":  [],
+						"security_groups":  [],
+					},
+				],
+				"owner_id": true,
+				"vpc_id":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "foo",
+		"provider_name":  "aws",
+		"type":           "aws_security_group",
+	},
+	"aws_security_group.foo": {
+		"address": "aws_security_group.foo",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"description": "foo",
+				"ingress": [
+					{
 						"cidr_blocks": [
 							"10.0.0.0/16",
 						],
@@ -307,6 +361,41 @@ resource_changes = {
 		"mode":           "managed",
 		"module_address": "",
 		"name":           "ham",
+		"provider_name":  "aws",
+		"type":           "aws_security_group_rule",
+	},
+	"aws_security_group_rule.self": {
+		"address": "aws_security_group_rule.self",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"cidr_blocks": null,
+				"description":      "self",
+				"from_port":        0,
+				"ipv6_cidr_blocks": null,
+				"prefix_list_ids":  null,
+				"protocol":         "tcp",
+				"self":             true,
+				"to_port":          1024,
+				"type":             "ingress",
+			},
+			"after_unknown": {
+				"cidr_blocks": [
+					false,
+				],
+				"id":                       true,
+				"security_group_id":        true,
+				"source_security_group_id": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "self",
 		"provider_name":  "aws",
 		"type":           "aws_security_group_rule",
 	},

--- a/policies/deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
+++ b/policies/deny-public-ssh-acl-rules/testdata/mock-tfplan-success.sentinel
@@ -121,7 +121,7 @@ resource_changes = {
 				"description": "foo",
 				"ingress": [
 					{
-						"cidr_blocks": null,
+						"cidr_blocks":      null,
 						"description":      "foo",
 						"from_port":        22,
 						"ipv6_cidr_blocks": [],
@@ -371,7 +371,7 @@ resource_changes = {
 				"create",
 			],
 			"after": {
-				"cidr_blocks": null,
+				"cidr_blocks":      null,
 				"description":      "self",
 				"from_port":        0,
 				"ipv6_cidr_blocks": null,


### PR DESCRIPTION
If I have a security group that matches these ports that is allowing access to itself via self: true, this Sentinel policy gets flagged due to an error where it can't handle a null cidr_blocks attribute.

These policies should ignore these ports/protocols with security groups that reference themselves.

Error output:
```shell
Enforcement Mode: advisory

CIS 4.1: Ensure no AWS security groups allow ingress from 0.0.0.0/0 to port 22

An error occurred:
    ./aws-cis-4.1-networking-deny-public-ssh-acl-rules.sentinel:69:3: left operand for contains must be list, map, or string got null
```
Plan output that caused the error:
```
  # module.example.module.example.aws_security_group_rule.ingress_self will be created
  + resource "aws_security_group_rule" "ingress_self" {
      + description              = "example self referential."
      + from_port                = 0
      + id                       = (known after apply)
      + protocol                 = "-1"
      + security_group_id        = (known after apply)
      + self                     = true
      + source_security_group_id = (known after apply)
      + to_port                  = 0
      + type                     = "ingress"
    }

```
This draft PR hopefully helps give context to the desired outcome, although I'm very new to Sentinel so apologies for any mistakes, and please double check my logic, I'm operating under the assumption that if self: true then cidr_blocks will be null all the time.

Related links:

https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule#self
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group#self
Thanks in advance for your review!